### PR TITLE
fix: display crit and fumble result details in QoL cards

### DIFF
--- a/templates/partials/_crit-button.html
+++ b/templates/partials/_crit-button.html
@@ -17,8 +17,16 @@ hitsTarget))}} {{#if canUserModify}} {{#if compact}}
 </div>
 {{/if}} {{/if}} {{/unless}} {{else}} {{#if compact}}
 <span class="compact-auto-result">{{{automatedCritDisplay}}}</span>
+{{#if automatedCritDetails}}
+<div class="compact-auto-result">{{{automatedCritDetails}}}</div>
+{{/if}}
 {{else}}
 <div class="chat-details centered">
     <div class="roll-result status-info">{{{automatedCritDisplay}}}</div>
 </div>
+{{#if automatedCritDetails}}
+<div class="chat-details centered">
+    <div class="roll-result">{{{automatedCritDetails}}}</div>
+</div>
+{{/if}}
 {{/if}} {{/unless}}

--- a/templates/partials/_fumble-button.html
+++ b/templates/partials/_fumble-button.html
@@ -16,8 +16,16 @@
 </div>
 {{/if}} {{/if}} {{else}} {{#if compact}}
 <div class="compact-auto-result">{{{automatedFumbleDisplay}}}</div>
+{{#if automatedFumbleDetails}}
+<div class="compact-auto-result">{{{automatedFumbleDetails}}}</div>
+{{/if}}
 {{else}}
 <div class="chat-details centered">
     <div class="roll-result status-info">{{{automatedFumbleDisplay}}}</div>
 </div>
+{{#if automatedFumbleDetails}}
+<div class="chat-details centered">
+    <div class="roll-result">{{{automatedFumbleDetails}}}</div>
+</div>
+{{/if}}
 {{/if}} {{/unless}}


### PR DESCRIPTION
## Summary
- Display `automatedCritDetails` and `automatedFumbleDetails` in the QoL attack cards
- Previously only the roll number and table link were shown, but not the actual result text from the crit/fumble table lookup

## Problem
When a crit or fumble was rolled with the DCC system's "Automate Rolling Damage, Crits, and Fumbles" setting enabled, the QoL card would show:
- "Crit Result 7 (Crit Table IV)"

But it would NOT show the actual table result description (e.g., "Force foe back 5' and inflict +1d6 damage with this strike").

## Root Cause
The DCC system provides two pieces of data:
- `critInlineRoll` / `fumbleInlineRoll` - the roll number and table link
- `critText` / `fumbleText` - the actual result description

The QoL module was capturing both (as `automatedCritDisplay`/`automatedCritDetails`), but the templates were only rendering the display, not the details.

## Fix
Updated `_crit-button.html` and `_fumble-button.html` templates to also render `automatedCritDetails` and `automatedFumbleDetails` when present.

## Test plan
- [ ] Roll an attack that results in a critical hit with "Automate Rolling Damage, Crits, and Fumbles" enabled
- [ ] Verify the crit result description is now shown below the roll info
- [ ] Roll an attack that results in a fumble
- [ ] Verify the fumble result description is now shown below the roll info
- [ ] Test both standard and compact card formats