### PR TITLE
fix: enforce minimum 1 damage on damage rolls

### DIFF
--- a/scripts/chatCardActions/handleDamageClick.js
+++ b/scripts/chatCardActions/handleDamageClick.js
@@ -69,6 +69,11 @@ export async function handleDamageClick(
         );
         await roll.evaluate();
 
+        // Enforce minimum 1 damage (matching DCC system auto-roll behavior)
+        if (roll.total < 1) {
+            roll._total = 1;
+        }
+
         let flavorText = `Rolling Damage for ${
             message.system.weaponName || weapon?.name || "weapon"
         }`;


### PR DESCRIPTION
## Summary
- Clamp damage roll total to minimum 1 after evaluation in `handleDamageClick`, matching DCC system's auto-roll behavior
- Required because DCC system no longer wraps damage formulas with `max()` (see foundryvtt-dcc/dcc#716), so formulas like `1d4-2` can produce totals below 1
- Without this, `automatedDamageTotal` flag could be set to 0 or negative, causing automated damage application to silently skip

## Test plan
- [ ] Create NPC with weapon, add Active Effect with negative damage adjustment (e.g., `system.details.attackDamageBonus.melee.adjustment = -2`)
- [ ] Attack and hit a target — click the dcc-qol Roll Damage button
- [ ] If the roll result is < 1, verify the damage total shows as 1 and is applied correctly to the target

🤖 Generated with [Claude Code](https://claude.com/claude-code)