### PR TITLE
Potential fix for code scanning alert no. 3: Prototype-polluting function

### DIFF
--- a/scripts/__mocks__/foundry.js
+++ b/scripts/__mocks__/foundry.js
@@ -506,6 +506,10 @@ global.foundry.utils.mergeObject = function (
             toDelete = v === null;
         }
 
+        // Prevent prototype pollution
+        if (k === "__proto__" || k === "constructor" || k === "prototype")
+            continue;
+
         // Get the existing object
         let x = original[k];
         let has = Object.prototype.hasOwnProperty.call(original, k);


### PR DESCRIPTION
Potential fix for [https://github.com/tonyrobots/dcc-qol/security/code-scanning/3](https://github.com/tonyrobots/dcc-qol/security/code-scanning/3)

The safest minimal fix is to **block prototype-pollution keys** (`"__proto__"`, `"constructor"`, and `"prototype"`) early in the merge loop, before any use of `original[k]`, recursion, deletion, or assignment. This preserves existing behavior for normal keys while preventing writes/traversal into prototype chains.

In `scripts/__mocks__/foundry.js`, inside `global.foundry.utils.mergeObject`, update the loop that iterates `Object.entries(other)`:
- After handling `-=` prefix normalization, add a guard:
  - `if (k === "__proto__" || k === "constructor" || k === "prototype") continue;`
This ensures dangerous keys are ignored in both top-level and recursive merges without changing other merge semantics.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
