### PR TITLE
fix: render the system's Mighty Deed prompt on the QoL attack card

### DIFF
--- a/scripts/__mocks__/foundry.js
+++ b/scripts/__mocks__/foundry.js
@@ -322,10 +322,19 @@ global.calculateCritAdjustment = jest
 global.updateFlagsMock = jest
     .fn((flags, roll) => {})
     .mockName("game.dcc.FleetingLuck.updateFlags");
+global.buildMightyDeedPromptMock = jest
+    .fn()
+    .mockReturnValue("")
+    .mockName("game.dcc.buildMightyDeedPrompt");
+global.attachMightyDeedListenersMock = jest
+    .fn()
+    .mockName("game.dcc.attachMightyDeedListeners");
 global.game.dcc = {
     DCCRoll,
     getSkillTable: global.getDCCSkillTableMock,
     processSpellCheck: global.processSpellCheckMock,
+    buildMightyDeedPrompt: global.buildMightyDeedPromptMock,
+    attachMightyDeedListeners: global.attachMightyDeedListenersMock,
     Rolls: {
         get: jest.fn(),
     },

--- a/scripts/__tests__/chatMessageHooks.test.js
+++ b/scripts/__tests__/chatMessageHooks.test.js
@@ -270,6 +270,66 @@ describe("Chat Message Hooks", () => {
             });
         });
 
+        describe("Mighty Deed prompt (DCC system #319)", () => {
+            it("passes the system-built deed prompt markup into the template", async () => {
+                // Arrange - the DCC system exposes the prompt builder; QoL must
+                // render the identical prompt inside its own card since it
+                // replaces .message-content wholesale.
+                game.dcc.buildMightyDeedPrompt.mockReturnValue(
+                    '<div class="deed-table-prompt" data-deed-roll="4"><button class="roll-deed-table">Roll Deed</button></div>'
+                );
+
+                // Act
+                await enhanceAttackRollCard(mockMessage, html, {});
+
+                // Assert - builder called with the message, result threaded to template
+                expect(game.dcc.buildMightyDeedPrompt).toHaveBeenCalledWith(
+                    mockMessage
+                );
+                expect(renderTemplate).toHaveBeenCalledWith(
+                    expect.any(String),
+                    expect.objectContaining({
+                        deedPromptHTML:
+                            expect.stringContaining("deed-table-prompt"),
+                    })
+                );
+            });
+
+            it("wires the system's deed listener onto the rebuilt card", async () => {
+                // Arrange
+                renderTemplate.mockResolvedValue(
+                    '<div class="dccqol chat-card"><div class="deed-table-prompt" data-deed-roll="4"><button class="roll-deed-table">Roll Deed</button></div></div>'
+                );
+
+                // Act
+                await enhanceAttackRollCard(mockMessage, html, {});
+
+                // Assert - QoL hands the rebuilt content to the system's attach helper
+                expect(
+                    game.dcc.attachMightyDeedListeners
+                ).toHaveBeenCalledTimes(1);
+                const [, cardElement] =
+                    game.dcc.attachMightyDeedListeners.mock.calls[0];
+                expect(
+                    cardElement.querySelector(".roll-deed-table")
+                ).not.toBeNull();
+            });
+
+            it("passes an empty deed prompt when no deed tables are offered", async () => {
+                // Arrange - builder default returns "" (no deed success / tables)
+                game.dcc.buildMightyDeedPrompt.mockReturnValue("");
+
+                // Act
+                await enhanceAttackRollCard(mockMessage, html, {});
+
+                // Assert
+                expect(renderTemplate).toHaveBeenCalledWith(
+                    expect.any(String),
+                    expect.objectContaining({ deedPromptHTML: "" })
+                );
+            });
+        });
+
         describe("Conditional Behavior", () => {
             it("should not enhance card when QoL flags are missing", async () => {
                 // Arrange

--- a/scripts/hooks/chatMessageHooks.js
+++ b/scripts/hooks/chatMessageHooks.js
@@ -97,12 +97,23 @@ export async function enhanceAttackRollCard(message, html, data) {
                 qolFlags.options || {}
             );
 
+            // --- Build the Mighty Deed table prompt (if any) ---
+            // The DCC system renders a "Roll Deed" prompt on its own attack card
+            // when a warrior's/dwarf's deed die succeeds and Mighty Deed tables
+            // are configured. Because we replace .message-content wholesale, we
+            // must render the identical prompt ourselves. game.dcc exposes the
+            // markup builder (and the listener attach below) so the lookup logic
+            // stays owned by the system. Guarded for older system versions.
+            const deedPromptHTML =
+                game.dcc?.buildMightyDeedPrompt?.(message) || "";
+
             // --- Prepare Template Data ---
             const templateData = {
                 ...qolFlags, // Includes deedDieResult and now isPC from flags
                 actor: actor,
                 weapon: weapon,
                 diceHTML: diceHTML, // Pass the extracted attack roll HTML
+                deedPromptHTML: deedPromptHTML, // Mighty Deed prompt markup (or "")
                 properties: properties,
                 messageId: message.id,
                 // Add attack card format setting for template logic
@@ -164,6 +175,11 @@ export async function enhanceAttackRollCard(message, html, data) {
             // --- Add Event Listeners for QoL Card Buttons ---
             // Determine the correct element to attach listeners to (either the specific .message-content div or the whole html if .message-content wasn't found)
             const cardElement = messageContentElement || html;
+
+            // Wire up the Mighty Deed table prompt we rendered above. The system
+            // owns the lookup handler; we just (re)attach it to our rebuilt card.
+            // Safe no-op when the prompt isn't present or on older systems.
+            game.dcc?.attachMightyDeedListeners?.(message, cardElement);
 
             const damageButton = cardElement.querySelector(
                 'button[data-action="damage"]'

--- a/templates/attackroll-card-compact.html
+++ b/templates/attackroll-card-compact.html
@@ -66,6 +66,7 @@
         {{#if deedDieResult}}
             {{localize "DCC.DeedDie"}}: <strong>{{deedDieResult}}</strong>
         {{/if}}
+        {{#if deedPromptHTML}}{{{deedPromptHTML}}}{{/if}}
     </div>
 
     {{#if isFumble}}

--- a/templates/attackroll-card.html
+++ b/templates/attackroll-card.html
@@ -65,7 +65,7 @@
     <div class="roll-result">
         {{localize "DCC.DeedDie"}}: <strong>{{deedDieResult}}</strong>
     </div>
-    {{/if}} {{#if isFumble}}
+    {{/if}} {{#if deedPromptHTML}}{{{deedPromptHTML}}}{{/if}} {{#if isFumble}}
     <div class="chat-details centered">
         <div class="roll-result status-failure">{{localize "DCC.Fumble"}}!</div>
     </div>


### PR DESCRIPTION
## Problem

The DCC system ([#319](https://github.com/foundryvtt-dcc/dcc/issues/319)) renders a Mighty Deed table prompt (a `<select>` of deed tables + a "Roll Deed" button) on its attack card when a warrior's/dwarf's deed die succeeds and `mightyDeedsEnabled` is on. Because `enhanceAttackRollCard` replaces `.message-content` **wholesale** with our own template, that prompt — and its click handler — were destroyed whenever the QoL attack card was enabled (the default). The feature was effectively invisible to anyone running dcc-qol.

## Fix

Render the identical prompt inside our own card, reusing the system's markup builder and lookup handler so the logic stays owned by the system (no duplication, no drift):

- Build `deedPromptHTML` via `game.dcc.buildMightyDeedPrompt(message)` and thread it into both the full (`attackroll-card.html`) and compact (`attackroll-card-compact.html`) templates.
- After rebuilding the card, call `game.dcc.attachMightyDeedListeners` to wire the system's lookup handler onto our prompt. It's idempotent on the system side, so this doesn't double-bind / double-roll.
- All calls are optional-chained, so an older system without the API is a safe no-op (the prompt simply doesn't render — matching prior behaviour).

Requires the companion system change (the `game.dcc.buildMightyDeedPrompt` / `attachMightyDeedListeners` API): foundryvtt-dcc/dcc#764. dcc-qol is already pinned to DCC `>= 0.70.0`; that PR lands the API.

## Tests

- 46 tests pass (was 43). Added `chatMessageHooks` coverage for the prompt data threading (`deedPromptHTML` populated and empty) and listener wiring, plus the new `game.dcc` mock entries.
- Prettier clean.